### PR TITLE
Update DefaultDkimSigner.cs

### DIFF
--- a/Src/Exchange.DkimSigner/DefaultDkimSigner.cs
+++ b/Src/Exchange.DkimSigner/DefaultDkimSigner.cs
@@ -242,7 +242,7 @@
             bool ruleMatch = false;
             foreach (string to in toDomains) {
                 MailAddress addr = new MailAddress(to);
-                ruleMatch |= Regex.Match(addr.Host, domainFound.RecipientRule).Success;
+                ruleMatch |= Regex.Match(addr.Address, domainFound.RecipientRule).Success;
                 if (ruleMatch)
                     break;
             }


### PR DESCRIPTION
Why the RecipientRule should just check the host? It's more logic to check the address like the SenderRule does.
