### PR TITLE
Fix: "Check DNS" only shows the first line of a multiline TXT record

### DIFF
--- a/Src/Configuration.DkimSigner/MainWindow.cs
+++ b/Src/Configuration.DkimSigner/MainWindow.cs
@@ -1048,7 +1048,7 @@ namespace Configuration.DkimSigner
                 if (oResponse.RecordsTXT.GetLength(0) > 0)
                 {
                     RecordTXT oTxtRecord = oResponse.RecordsTXT[0];
-                    this.txtDomainDNS.Text = oTxtRecord.TXT.Count > 0 ? oTxtRecord.TXT[0] : "No record found for " + sFullDomain;
+                    this.txtDomainDNS.Text = oTxtRecord.TXT.Count > 0 ? string.Join(string.Empty, oTxtRecord.TXT) : "No record found for " + sFullDomain;
                 }
                 else
                 {


### PR DESCRIPTION
Join all the lines of a multiline TXT record rather than just showing the first line.  TXT records with long keys can often be split across multiple lines of a TXT record.