### PR TITLE
Fix crash when enable/disable agent is pressed

### DIFF
--- a/Src/Configuration.DkimSigner/Exchange/ExchangeServer.cs
+++ b/Src/Configuration.DkimSigner/Exchange/ExchangeServer.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.ServiceProcess;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Configuration.DkimSigner.Exchange
@@ -134,7 +131,7 @@ namespace Configuration.DkimSigner.Exchange
                 Match oMatch = Regex.Match(sResult, "^Uninstall-TransportAgent", RegexOptions.IgnoreCase);
                 if (oMatch.Success)
                 {
-                    throw new ExchangeServerException("Couldn't install 'Exchange DkimSigner' agent :\n");
+                    throw new ExchangeServerException("Couldn't uninstall 'Exchange DkimSigner' agent :\n");
                 }
             }
         }
@@ -148,7 +145,7 @@ namespace Configuration.DkimSigner.Exchange
                 Match oMatch = Regex.Match(sResult, "^Enable-TransportAgent", RegexOptions.IgnoreCase);
                 if (oMatch.Success)
                 {
-                    throw new ExchangeServerException("Couldn't install 'Exchange DkimSigner' agent :\n");
+                    throw new ExchangeServerException("Couldn't enable 'Exchange DkimSigner' agent :\n");
                 }
             }
         }
@@ -162,7 +159,7 @@ namespace Configuration.DkimSigner.Exchange
                 Match oMatch = Regex.Match(sResult, "^Disable-TransportAgent", RegexOptions.IgnoreCase);
                 if (oMatch.Success)
                 {
-                    throw new ExchangeServerException("Couldn't install 'Exchange DkimSigner' agent :\n");
+                    throw new ExchangeServerException("Couldn't disable 'Exchange DkimSigner' agent :\n");
                 }
             }
         }
@@ -176,7 +173,7 @@ namespace Configuration.DkimSigner.Exchange
                 Match oMatch = Regex.Match(sResult, "^Set-TransportAgent", RegexOptions.IgnoreCase);
                 if (oMatch.Success)
                 {
-                    throw new ExchangeServerException("Couldn't install 'Exchange DkimSigner' agent :\n");
+                    throw new ExchangeServerException("Couldn't set priority of 'Exchange DkimSigner' agent :\n");
                 }
             }
         }

--- a/Src/Configuration.DkimSigner/Exchange/PowershellHelper.cs
+++ b/Src/Configuration.DkimSigner/Exchange/PowershellHelper.cs
@@ -70,7 +70,6 @@ namespace Configuration.DkimSigner.Exchange
         {
             StringBuilder sb = new StringBuilder();
             Pipeline pipeline = null;
-            Exception except = null;
 
             try
             {
@@ -82,28 +81,12 @@ namespace Configuration.DkimSigner.Exchange
 
                 foreach (PSObject current in collection)
                 {
-                    sb.AppendLine(current.ToString());
-                }
-
-                if (bRemoveEmptyLines)
-                {
-                    string[] array = sb.ToString().Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                    sb = new StringBuilder();
-
-                    for (int i = 0; i < array.Length; i++)
+                    string value = current.ToString();
+                    if (!bRemoveEmptyLines || !string.IsNullOrWhiteSpace(value))
                     {
-                        string value = array[i].Trim();
-
-                        if (!string.IsNullOrEmpty(value))
-                        {
-                            sb.AppendLine(value);
-                        }
+                        sb.AppendLine(value);
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                except = ex;
             }
             finally
             {
@@ -111,11 +94,6 @@ namespace Configuration.DkimSigner.Exchange
                 {
                     pipeline.Dispose();
                 }
-            }
-
-            if (except != null)
-            {
-                throw except;
             }
 
             return sb.ToString();

--- a/Src/Configuration.DkimSigner/Exchange/PowershellHelper.cs
+++ b/Src/Configuration.DkimSigner/Exchange/PowershellHelper.cs
@@ -81,10 +81,14 @@ namespace Configuration.DkimSigner.Exchange
 
                 foreach (PSObject current in collection)
                 {
-                    string value = current.ToString();
-                    if (!bRemoveEmptyLines || !string.IsNullOrWhiteSpace(value))
+                    string[] array = current.ToString().Split(new[] { '\n' }, (bRemoveEmptyLines ? StringSplitOptions.RemoveEmptyEntries : StringSplitOptions .None));
+
+                    foreach(string value in array)
                     {
-                        sb.AppendLine(value);
+                        if(!bRemoveEmptyLines || !string.IsNullOrWhiteSpace(value))
+                        {
+                            sb.AppendLine(value.Trim());
+                        }
                     }
                 }
             }

--- a/Src/Configuration.DkimSigner/Exchange/TransportService.cs
+++ b/Src/Configuration.DkimSigner/Exchange/TransportService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.ServiceProcess;
 using System.Threading;
@@ -82,7 +81,10 @@ namespace Configuration.DkimSigner.Exchange
                 if (this.status != status)
                 {
                     this.status = status;
-                    this.StatusChanged(this, null);
+                    if(this.StatusChanged != null)
+                    {
+                        this.StatusChanged(this, null);
+                    }
                 }
             }
             catch (ExchangeServerException)

--- a/Src/Configuration.DkimSigner/ExchangeTransportServiceWindow.cs
+++ b/Src/Configuration.DkimSigner/ExchangeTransportServiceWindow.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
-
 using Configuration.DkimSigner.Exchange;
-using System.IO;
 
 namespace Configuration.DkimSigner
 {
@@ -32,7 +30,6 @@ namespace Configuration.DkimSigner
         private void ExchangeTransportServiceWindows_Load(object sender, EventArgs e)
         {
             this.RefreshTransportServiceAgents();
-
         }
 
         private void dgvTransportServiceAgents_SelectionChanged(object sender, EventArgs e)

--- a/Src/Configuration.DkimSigner/ExchangeTransportServiceWindow.cs
+++ b/Src/Configuration.DkimSigner/ExchangeTransportServiceWindow.cs
@@ -148,13 +148,14 @@ namespace Configuration.DkimSigner
                 if (this.btDisable.Text == "Disable")
                 {
                     ExchangeServer.DisableDkimTransportAgent();
-                    this.btDisable.Text = "Enable";
                 }
                 else
                 {
                     ExchangeServer.EnableDkimTransportAgent();
-                    this.btDisable.Text = "Disable";
                 }
+
+                this.RefreshTransportServiceAgents();
+                this.refreshMoveButtons( true );
 
                 TransportService ts = new TransportService();
                 try
@@ -169,8 +170,6 @@ namespace Configuration.DkimSigner
                 {
                     ts.Dispose();
                 }
-                this.RefreshTransportServiceAgents();
-                this.refreshMoveButtons(true);
             }
             catch (ExchangeServerException ex)
             {


### PR DESCRIPTION
Fixed a crash when pressing the enable/disable button on transport agent.  The transport service event was not being checked for null before used.

Did some code clean up and simplification as well.