### PR TITLE
Sign with rsa-sha256 by default

### DIFF
--- a/Src/Exchange.DkimSigner/Configuration/Settings.cs
+++ b/Src/Exchange.DkimSigner/Configuration/Settings.cs
@@ -21,7 +21,7 @@ namespace Exchange.DkimSigner.Configuration
         {
             Loglevel = 3;
 
-            SigningAlgorithm = DkimAlgorithmKind.RsaSha1;
+            SigningAlgorithm = DkimAlgorithmKind.RsaSha256;
             HeaderCanonicalization = DkimCanonicalizationKind.Simple;
             BodyCanonicalization = DkimCanonicalizationKind.Simple;
 


### PR DESCRIPTION
The RFC 6376 says:
"Signers MUST implement and SHOULD sign using rsa-sha256.
   Verifiers MUST implement both rsa-sha1 and rsa-sha256."
Reference: https://tools.ietf.org/html/rfc6376#section-3.3

So I think it would be better to use rsa-sha256 instead of rsa-sha1 by default.