### PR TITLE
Fix Event 1057 log messages

### DIFF
--- a/Src/Exchange.DkimSigner/DkimSigningRoutingAgent.cs
+++ b/Src/Exchange.DkimSigner/DkimSigningRoutingAgent.cs
@@ -63,11 +63,6 @@ namespace Exchange.DkimSigner
         {
             try
             {
-#if !EX_2007_SP3 //not supported in Exchange 2007
-                // This allows Transport poison detection to correclty handle this message
-                // if there is a crash on this thread.
-                agentAsyncContext.Resume();
-#endif
                 SignMailItem((MailItem)mailItem);
             }
             catch (Exception ex)
@@ -76,6 +71,11 @@ namespace Exchange.DkimSigner
             }
             finally
             {
+#if !EX_2007_SP3 //not supported in Exchange 2007
+                // This allows Transport poison detection to correclty handle this message
+                // if there is a crash on this thread.
+                agentAsyncContext.Resume();
+#endif
                 agentAsyncContext.Complete();
                 agentAsyncContext = null;
             }


### PR DESCRIPTION
See #112
I did some testing and came to the same conclusion as https://github.com/Pro/dkim-exchange/issues/112#issuecomment-262859534 ... That EventLog message only goes away if `Resume()` is called immediately before `Complete()`.
So, this commit implements that change.