### PR TITLE
Add Server Core support for Open/Save File Dialogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ UpgradeLog*.XML
 /Src/Configuration.DkimSigner/bin/Release/Configuration.DkimSigner.vshost.exe.manifest
 /cov-int
 /cov-int.zip
+.vscode/tasks.json

--- a/Src/Configuration.DkimSigner/Configuration.DkimSigner.csproj
+++ b/Src/Configuration.DkimSigner/Configuration.DkimSigner.csproj
@@ -1,203 +1,203 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-	<PropertyGroup>
-		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-		<ProjectGuid>{522FE7A3-2756-48B3-BE64-68B291B50863}</ProjectGuid>
-		<OutputType>WinExe</OutputType>
-		<RootNamespace>Configuration.DkimSigner</RootNamespace>
-		<AssemblyName>Configuration.DkimSigner</AssemblyName>
-		<TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-		<FileAlignment>512</FileAlignment>
-		<AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
-		<Deterministic>false</Deterministic>
-		<PublishUrl>publish\</PublishUrl>
-		<Install>true</Install>
-		<InstallFrom>Disk</InstallFrom>
-		<UpdateEnabled>false</UpdateEnabled>
-		<UpdateMode>Foreground</UpdateMode>
-		<UpdateInterval>7</UpdateInterval>
-		<UpdateIntervalUnits>Days</UpdateIntervalUnits>
-		<UpdatePeriodically>false</UpdatePeriodically>
-		<UpdateRequired>false</UpdateRequired>
-		<MapFileExtensions>true</MapFileExtensions>
-		<ApplicationRevision>0</ApplicationRevision>
-		<ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-		<IsWebBootstrapper>false</IsWebBootstrapper>
-		<UseApplicationTrust>false</UseApplicationTrust>
-		<BootstrapperEnabled>true</BootstrapperEnabled>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-		<PlatformTarget>AnyCPU</PlatformTarget>
-		<DebugSymbols>true</DebugSymbols>
-		<DebugType>full</DebugType>
-		<Optimize>false</Optimize>
-		<OutputPath>bin\Debug\</OutputPath>
-		<DefineConstants>DEBUG;TRACE</DefineConstants>
-		<ErrorReport>prompt</ErrorReport>
-		<WarningLevel>4</WarningLevel>
-		<Prefer32Bit>false</Prefer32Bit>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-		<PlatformTarget>AnyCPU</PlatformTarget>
-		<DebugType>none</DebugType>
-		<Optimize>true</Optimize>
-		<OutputPath>bin\Release\</OutputPath>
-		<DefineConstants>TRACE</DefineConstants>
-		<ErrorReport>prompt</ErrorReport>
-		<WarningLevel>4</WarningLevel>
-		<Prefer32Bit>false</Prefer32Bit>
-	</PropertyGroup>
-	<PropertyGroup>
-		<ApplicationManifest>app.manifest</ApplicationManifest>
-	</PropertyGroup>
-	<PropertyGroup>
-		<ApplicationIcon>..\..\Resources\Saki-NuoveXT-2-Mimetypes-document-seal.ico</ApplicationIcon>
-	</PropertyGroup>
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.IO.Compression" />
-		<Reference Include="System.IO.Compression.FileSystem" />
-		<Reference Include="System.Runtime.Serialization" />
-		<Reference Include="System.Security" />
-		<Reference Include="System.ServiceProcess" />
-		<Reference Include="System.Xml.Linq" />
-		<Reference Include="System.Data.DataSetExtensions" />
-		<Reference Include="Microsoft.CSharp" />
-		<Reference Include="System.Data" />
-		<Reference Include="System.Deployment" />
-		<Reference Include="System.Drawing" />
-		<Reference Include="System.Net.Http" />
-		<Reference Include="System.Windows.Forms" />
-		<Reference Include="System.Xml" />
-	</ItemGroup>
-	<ItemGroup>
-		<Compile Include="..\Exchange.DkimSigner\Configuration\DkimAlgorithmKind.cs">
-			<Link>Configuration\DkimAlgorithmKind.cs</Link>
-		</Compile>
-		<Compile Include="..\Exchange.DkimSigner\Configuration\DkimCanonicalizationKind.cs">
-			<Link>Configuration\DkimCanonicalizationKind.cs</Link>
-		</Compile>
-		<Compile Include="..\Exchange.DkimSigner\Configuration\DomainElement.cs">
-			<Link>Configuration\DomainElement.cs</Link>
-		</Compile>
-		<Compile Include="..\Exchange.DkimSigner\Configuration\Settings.cs">
-			<Link>Configuration\Settings.cs</Link>
-		</Compile>
-		<Compile Include="..\Exchange.DkimSigner\Helper\KeyHelper.cs">
-			<Link>Helper\KeyHelper.cs</Link>
-		</Compile>
-		<Compile Include="Configuration\CplControl.cs" />
-		<Compile Include="Configuration\UninstallerRegistry.cs" />
-		<Compile Include="Constants.cs" />
-		<Compile Include="DownloadProgressWindow.cs">
-			<SubType>Form</SubType>
-		</Compile>
-		<Compile Include="DownloadProgressWindow.Designer.cs">
-			<DependentUpon>DownloadProgressWindow.cs</DependentUpon>
-		</Compile>
-		<Compile Include="ExchangeTransportServiceWindow.cs">
-			<SubType>Form</SubType>
-		</Compile>
-		<Compile Include="ExchangeTransportServiceWindow.Designer.cs">
-			<DependentUpon>ExchangeTransportServiceWindow.cs</DependentUpon>
-		</Compile>
-		<Compile Include="Exchange\ExchangeServer.cs" />
-		<Compile Include="Exchange\ExchangeServerException.cs" />
-		<Compile Include="Exchange\PowershellHelper.cs" />
-		<Compile Include="Exchange\TransportService.cs" />
-		<Compile Include="Exchange\TransportServiceAction.cs" />
-		<Compile Include="Exchange\TransportServiceAgent.cs" />
-		<Compile Include="FileIO\FileOperation.cs" />
-		<Compile Include="FileIO\ShellFileOperation.cs" />
-		<Compile Include="GitHub\Api.cs" />
-		<Compile Include="GitHub\ApiWrapper.cs" />
-		<Compile Include="GitHub\DataContract.cs" />
-		<Compile Include="HeaderInputWindow.cs">
-			<SubType>Form</SubType>
-		</Compile>
-		<Compile Include="HeaderInputWindow.Designer.cs">
-			<DependentUpon>HeaderInputWindow.cs</DependentUpon>
-		</Compile>
-		<Compile Include="InstallWindow.cs">
-			<SubType>Form</SubType>
-		</Compile>
-		<Compile Include="InstallWindow.Designer.cs">
-			<DependentUpon>InstallWindow.cs</DependentUpon>
-		</Compile>
-		<Compile Include="MainWindow.cs">
-			<SubType>Form</SubType>
-		</Compile>
-		<Compile Include="MainWindow.Designer.cs">
-			<DependentUpon>MainWindow.cs</DependentUpon>
-		</Compile>
-		<Compile Include="Program.cs" />
-		<Compile Include="Properties\AssemblyInfo.cs" />
-		<Compile Include="UninstallWindow.cs">
-			<SubType>Form</SubType>
-		</Compile>
-		<Compile Include="UninstallWindow.Designer.cs">
-			<DependentUpon>UninstallWindow.cs</DependentUpon>
-		</Compile>
-		<Compile Include="UserPreferences.Designer.cs">
-			<AutoGen>True</AutoGen>
-			<DesignTimeSharedInput>True</DesignTimeSharedInput>
-			<DependentUpon>UserPreferences.settings</DependentUpon>
-		</Compile>
-		<EmbeddedResource Include="DownloadProgressWindow.resx">
-			<DependentUpon>DownloadProgressWindow.cs</DependentUpon>
-		</EmbeddedResource>
-		<EmbeddedResource Include="ExchangeTransportServiceWindow.resx">
-			<DependentUpon>ExchangeTransportServiceWindow.cs</DependentUpon>
-		</EmbeddedResource>
-		<EmbeddedResource Include="HeaderInputWindow.resx">
-			<DependentUpon>HeaderInputWindow.cs</DependentUpon>
-		</EmbeddedResource>
-		<EmbeddedResource Include="MainWindow.resx">
-			<DependentUpon>MainWindow.cs</DependentUpon>
-		</EmbeddedResource>
-		<EmbeddedResource Include="InstallWindow.resx">
-			<DependentUpon>InstallWindow.cs</DependentUpon>
-		</EmbeddedResource>
-		<EmbeddedResource Include="UninstallWindow.resx">
-			<DependentUpon>UninstallWindow.cs</DependentUpon>
-		</EmbeddedResource>
-	</ItemGroup>
-	<ItemGroup>
-		<None Include="App.config" />
-		<None Include="app.manifest" />
-		<None Include="COPYING.LESSER">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Include="UserPreferences.settings">
-			<Generator>SettingsSingleFileGenerator</Generator>
-			<LastGenOutput>UserPreferences.Designer.cs</LastGenOutput>
-		</None>
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="Heijden.Dns">
-			<Version>2.0.0</Version>
-		</PackageReference>
-		<PackageReference Include="Microsoft.PowerShell.4.ReferenceAssemblies">
-			<Version>1.0.0</Version>
-		</PackageReference>
-		<PackageReference Include="MimeKit">
-			<Version>2.15.1</Version>
-		</PackageReference>
-	</ItemGroup>
-	<ItemGroup>
-		<BootstrapperPackage Include=".NETFramework,Version=v4.7.2">
-			<Visible>False</Visible>
-			<ProductName>Microsoft .NET Framework 4.7.2 %28x86 and x64%29</ProductName>
-			<Install>true</Install>
-		</BootstrapperPackage>
-		<BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-			<Visible>False</Visible>
-			<ProductName>.NET Framework 3.5 SP1</ProductName>
-			<Install>false</Install>
-		</BootstrapperPackage>
-	</ItemGroup>
-	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{522FE7A3-2756-48B3-BE64-68B291B50863}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>Configuration.DkimSigner</RootNamespace>
+    <AssemblyName>Configuration.DkimSigner</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+    <Deterministic>false</Deterministic>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationIcon>..\..\Resources\Saki-NuoveXT-2-Mimetypes-document-seal.ico</ApplicationIcon>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Deployment" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Exchange.DkimSigner\Configuration\DkimAlgorithmKind.cs">
+      <Link>Configuration\DkimAlgorithmKind.cs</Link>
+    </Compile>
+    <Compile Include="..\Exchange.DkimSigner\Configuration\DkimCanonicalizationKind.cs">
+      <Link>Configuration\DkimCanonicalizationKind.cs</Link>
+    </Compile>
+    <Compile Include="..\Exchange.DkimSigner\Configuration\DomainElement.cs">
+      <Link>Configuration\DomainElement.cs</Link>
+    </Compile>
+    <Compile Include="..\Exchange.DkimSigner\Configuration\Settings.cs">
+      <Link>Configuration\Settings.cs</Link>
+    </Compile>
+    <Compile Include="..\Exchange.DkimSigner\Helper\KeyHelper.cs">
+      <Link>Helper\KeyHelper.cs</Link>
+    </Compile>
+    <Compile Include="Configuration\CplControl.cs" />
+    <Compile Include="Configuration\UninstallerRegistry.cs" />
+    <Compile Include="Constants.cs" />
+    <Compile Include="DownloadProgressWindow.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="DownloadProgressWindow.Designer.cs">
+      <DependentUpon>DownloadProgressWindow.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ExchangeTransportServiceWindow.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ExchangeTransportServiceWindow.Designer.cs">
+      <DependentUpon>ExchangeTransportServiceWindow.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Exchange\ExchangeServer.cs" />
+    <Compile Include="Exchange\ExchangeServerException.cs" />
+    <Compile Include="Exchange\PowershellHelper.cs" />
+    <Compile Include="Exchange\TransportService.cs" />
+    <Compile Include="Exchange\TransportServiceAction.cs" />
+    <Compile Include="Exchange\TransportServiceAgent.cs" />
+    <Compile Include="FileIO\FileOperation.cs" />
+    <Compile Include="FileIO\ShellFileOperation.cs" />
+    <Compile Include="GitHub\Api.cs" />
+    <Compile Include="GitHub\ApiWrapper.cs" />
+    <Compile Include="GitHub\DataContract.cs" />
+    <Compile Include="HeaderInputWindow.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="HeaderInputWindow.Designer.cs">
+      <DependentUpon>HeaderInputWindow.cs</DependentUpon>
+    </Compile>
+    <Compile Include="InstallWindow.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="InstallWindow.Designer.cs">
+      <DependentUpon>InstallWindow.cs</DependentUpon>
+    </Compile>
+    <Compile Include="MainWindow.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="MainWindow.Designer.cs">
+      <DependentUpon>MainWindow.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UninstallWindow.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UninstallWindow.Designer.cs">
+      <DependentUpon>UninstallWindow.cs</DependentUpon>
+    </Compile>
+    <Compile Include="UserPreferences.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <DependentUpon>UserPreferences.settings</DependentUpon>
+    </Compile>
+    <EmbeddedResource Include="DownloadProgressWindow.resx">
+      <DependentUpon>DownloadProgressWindow.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ExchangeTransportServiceWindow.resx">
+      <DependentUpon>ExchangeTransportServiceWindow.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="HeaderInputWindow.resx">
+      <DependentUpon>HeaderInputWindow.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="MainWindow.resx">
+      <DependentUpon>MainWindow.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="InstallWindow.resx">
+      <DependentUpon>InstallWindow.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UninstallWindow.resx">
+      <DependentUpon>UninstallWindow.cs</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="app.manifest" />
+    <None Include="COPYING.LESSER">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="UserPreferences.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>UserPreferences.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Heijden.Dns">
+      <Version>2.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.PowerShell.4.ReferenceAssemblies">
+      <Version>1.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="MimeKit">
+      <Version>2.15.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.7.2">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.7.2 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Src/Configuration.DkimSigner/InstallWindow.cs
+++ b/Src/Configuration.DkimSigner/InstallWindow.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -496,13 +497,30 @@ namespace Configuration.DkimSigner
 
 		private void btBrowse_Click(object sender, EventArgs e)
 		{
+			System.Windows.Forms.DialogResult result;
 			using (OpenFileDialog oFileDialog = new OpenFileDialog())
 			{
 				oFileDialog.FileName = "dkim-exchange.zip";
 				oFileDialog.Filter = "ZIP files|*.zip";
 				oFileDialog.Title = "Select the .zip file downloaded from github.com";
 
-				if (oFileDialog.ShowDialog() == DialogResult.OK)
+				try
+				{
+					result = oFileDialog.ShowDialog();
+				}
+				catch (COMException) when (oFileDialog.AutoUpgradeEnabled)
+				{
+					oFileDialog.AutoUpgradeEnabled = false;
+					try
+					{
+						result = oFileDialog.ShowDialog();
+					}
+					finally
+					{
+						oFileDialog.AutoUpgradeEnabled = true;
+					}
+				}
+				if (result == DialogResult.OK)
 				{
 					cbVersionWeb.SelectedIndex = -1;
 					txtVersionFile.Text = oFileDialog.FileName;

--- a/Src/Configuration.DkimSigner/MainWindow.cs
+++ b/Src/Configuration.DkimSigner/MainWindow.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -876,6 +877,7 @@ namespace Configuration.DkimSigner
 		/// <param name="e"></param>
 		private void btDomainKeyGenerate_Click(object sender, EventArgs e)
 		{
+			System.Windows.Forms.DialogResult result;
 			UserPreferences.Default.KeyLength = Convert.ToInt32(cbKeyLength.Text, 10);
 			UserPreferences.Default.Save();
 
@@ -896,7 +898,23 @@ namespace Configuration.DkimSigner
 					oFileDialog.FileName = txtDomainName.Text + ".pem";
 				}
 
-				if (oFileDialog.ShowDialog() == DialogResult.OK)
+				try
+                {
+					result = oFileDialog.ShowDialog();
+                }
+				catch (COMException) when (oFileDialog.AutoUpgradeEnabled)
+                {
+					oFileDialog.AutoUpgradeEnabled = false;
+					try
+                    {
+						result = oFileDialog.ShowDialog();
+                    }
+                    finally
+                    {
+						oFileDialog.AutoUpgradeEnabled = true;
+                    }
+                }
+				if (result == DialogResult.OK)
 				{
 					GenerateKey(oFileDialog.FileName);
 				}
@@ -961,6 +979,7 @@ namespace Configuration.DkimSigner
 		/// <param name="e"></param>
 		private void btDomainKeySelect_Click(object sender, EventArgs e)
 		{
+			System.Windows.Forms.DialogResult result;
 			using (OpenFileDialog oFileDialog = new OpenFileDialog())
 			{
 				oFileDialog.FileName = "key";
@@ -968,7 +987,24 @@ namespace Configuration.DkimSigner
 				oFileDialog.Title = "Select a private key for signing";
 				oFileDialog.InitialDirectory = Path.Combine(Constants.DkimSignerPath, "keys");
 
-				if (oFileDialog.ShowDialog() == DialogResult.OK)
+				try
+				{
+					result = oFileDialog.ShowDialog();
+				}
+				catch (COMException) when (oFileDialog.AutoUpgradeEnabled)
+				{
+					oFileDialog.AutoUpgradeEnabled = false;
+					try
+					{
+						result = oFileDialog.ShowDialog();
+					}
+					finally
+					{
+						oFileDialog.AutoUpgradeEnabled = true;
+					}
+				}
+
+				if (result == DialogResult.OK)
 				{
 					//Check if key can be parsed
 					try


### PR DESCRIPTION
Based on the code provided by @kpreisser here - https://github.com/microsoft/dotnet-framework-early-access/issues/23#issuecomment-393134611

This allows the Open File and Save File dialogs used by Configuration.DkimSigner.exe to use the legacy interfaces supported on Server Core installations.

Fixes # .

Changes included in this PR:
-
-
-
